### PR TITLE
Remove time fields and custom fields from sighting model

### DIFF
--- a/gumby/models.py
+++ b/gumby/models.py
@@ -172,10 +172,8 @@ class Encounter(Document):
     locationid = Keyword()
     # ENCOUNTER.SEX
     sex = EnumField(Sex, required=False)
-    # ENCOUNTER.GENUS
-    genus = Keyword()
-    # ANNOTATION.SPECIES
-    species = Keyword()
+    # ENCOUNTER.TAXONOMY_ID_OID => TAXONOMY.ID -> TAXONOMY.SCIENTIFICNAME
+    taxonomy = Keyword()
     # ENCOUNTER.LIVINGSTATUS
     living_status = EnumField(LivingStatus)
     # ENCOUNTER.LIFESTAGE

--- a/gumby/models.py
+++ b/gumby/models.py
@@ -193,11 +193,10 @@ class Sighting(Document):
     point = GeoPoint(required=False)
 
     # OCCURRENCE.ID => OCCURRENCE_ENCOUNTERS.ID_OID
-    #     -> OCCURRENCE_ENCOUNTERS.ID_EID => ENCOUNTER.ID -> ENCOUNTER.GENUS
-    genus = Keyword()
-    # => ENCOUNTER.ID => ENCOUNTER_ANNOTATIONS.ID_OID
-    #     -> ENCOUNTER_ANNOTATIONS.ID_EID => ANNOTATION.ID -> ANNOTATION.SPECIES
-    species = Keyword()
+    #     -> OCCURRENCE_ENCOUNTERS.ID_EID => ENCOUNTER.ID
+    #     -> ENCOUNTER.TAXONOMY_ID_OID => TAXONOMY.ID
+    #     -> TAXONOMY.SCIENTIFICNAME
+    taxonomy = Keyword()
     # OCCURRENCE.COMMENTS
     comments = Keyword()
 

--- a/gumby/models.py
+++ b/gumby/models.py
@@ -191,12 +191,6 @@ class Sighting(Document):
     id = UUIDField(required=True)
     # (OCCURRENCE.DECIMALLATITUDE, OCCURRENCE.DECIMALLONGITUDE)
     point = GeoPoint(required=False)
-    # OCCURRENCE.STARTTIME_COMPLEXDATETIME_ID_OID
-    #     => COMPLEXDATETIME.COMPLEXDATETIME_ID -> COMPLEXDATETIME.DATETIME
-    start_time = Date(required=False)
-    # OCCURRENCE.ENDTIME_COMPLEXDATETIME_ID_OID
-    #     => COMPLEXDATETIME.COMPLEXDATETIME_ID -> COMPLEXDATETIME.DATETIME
-    end_time = Date(required=False)
 
     # OCCURRENCE.ID => OCCURRENCE_ENCOUNTERS.ID_OID
     #     -> OCCURRENCE_ENCOUNTERS.ID_EID => ENCOUNTER.ID -> ENCOUNTER.GENUS
@@ -204,20 +198,6 @@ class Sighting(Document):
     # => ENCOUNTER.ID => ENCOUNTER_ANNOTATIONS.ID_OID
     #     -> ENCOUNTER_ANNOTATIONS.ID_EID => ANNOTATION.ID -> ANNOTATION.SPECIES
     species = Keyword()
-    # OCCURRENCE.GROUPBEHAVIOR
-    group_behavior = Keyword()
-    # OCCURRENCE.GROUPCOMPOSITION (empty for zebra)
-    group_composition = Keyword()
-    # OCCURRENCE.FIELDSTUDYSITE
-    field_study_site = Keyword()
-    # OCCURRENCE.INITIALCUE (empty for zebra)
-    initial_cue = Keyword()
-    # OCCURRENCE.SEASTATE (empty for zebra)
-    sea_state = Keyword()
-    # OCCURRENCE.HUMANACTIVITYNEARBY (empty for zebra)
-    human_activity_nearby = Keyword()
-    # OCCURRENCE.OBSERVER (empty for zebra)
-    observer = Keyword()
     # OCCURRENCE.COMMENTS
     comments = Keyword()
 

--- a/gumby/models.py
+++ b/gumby/models.py
@@ -176,8 +176,6 @@ class Encounter(Document):
     taxonomy = Keyword()
     # ENCOUNTER.LIVINGSTATUS
     living_status = EnumField(LivingStatus)
-    # ENCOUNTER.LIFESTAGE
-    lifestage = Keyword()
 
     class Index:
         name = 'encounters'


### PR DESCRIPTION
The time fields need to come from the houston database and
group_behavior, group_composition, field_study_site, initial_cue,
sea_state, human_activity_nearby and observer are going to come from
custom fields.

These will be implemented in a later PR.