### PR TITLE
Add datetime, time_specificity and custom_fields to Encounter and Sighting models

### DIFF
--- a/gumby/models.py
+++ b/gumby/models.py
@@ -9,6 +9,7 @@ from elasticsearch_dsl import (
     InnerDoc,
     Keyword,
     Nested,
+    Object,
     ValidationException,
 )
 
@@ -181,6 +182,8 @@ class Encounter(Document):
     #     -> houston.complex_date_time.datetime
     datetime = Date(required=False)
     time_specificity = Boolean(required=False)
+    # APICUSTOMFIELDS_CUSTOMFIELDVALUES
+    custom_fields = Object()
 
     class Index:
         name = 'encounters'
@@ -205,6 +208,8 @@ class Sighting(Document):
     taxonomy = Keyword()
     # OCCURRENCE.COMMENTS
     comments = Keyword()
+    # APICUSTOMFIELDS_CUSTOMFIELDVALUES
+    custom_fields = Object()
 
     class Index:
         name = 'sightings'

--- a/gumby/models.py
+++ b/gumby/models.py
@@ -176,6 +176,11 @@ class Encounter(Document):
     taxonomy = Keyword()
     # ENCOUNTER.LIVINGSTATUS
     living_status = EnumField(LivingStatus)
+    # OCCURRENCE.ID => houston.encounter.id
+    #     -> houston.encounter.time_guid => houston.complex_date_time.guid
+    #     -> houston.complex_date_time.datetime
+    datetime = Date(required=True)
+    time_specificity = Boolean(required=True)
 
     class Index:
         name = 'encounters'
@@ -187,6 +192,11 @@ class Sighting(Document):
     id = UUIDField(required=True)
     # (OCCURRENCE.DECIMALLATITUDE, OCCURRENCE.DECIMALLONGITUDE)
     point = GeoPoint(required=False)
+    # OCCURRENCE.ID => houston.sighting.id
+    #     -> houston.sighting.time_guid => houston.complex_date_time.guid
+    #     -> houston.complex_date_time.datetime
+    datetime = Date(required=True)
+    time_specificity = Boolean(required=True)
 
     # OCCURRENCE.ID => OCCURRENCE_ENCOUNTERS.ID_OID
     #     -> OCCURRENCE_ENCOUNTERS.ID_EID => ENCOUNTER.ID

--- a/gumby/models.py
+++ b/gumby/models.py
@@ -176,11 +176,11 @@ class Encounter(Document):
     taxonomy = Keyword()
     # ENCOUNTER.LIVINGSTATUS
     living_status = EnumField(LivingStatus)
-    # OCCURRENCE.ID => houston.encounter.id
+    # ENCOUNTER.ID => houston.encounter.id
     #     -> houston.encounter.time_guid => houston.complex_date_time.guid
     #     -> houston.complex_date_time.datetime
-    datetime = Date(required=True)
-    time_specificity = Boolean(required=True)
+    datetime = Date(required=False)
+    time_specificity = Boolean(required=False)
 
     class Index:
         name = 'encounters'


### PR DESCRIPTION
- Add datetime and time_specificity to Encounter and Sighting models


- Make datetime and time_specificity optional for encounters

  Jon said they are required for sightings but optional for encounters.

- Add custom_fields to Encounter and Sighting model

